### PR TITLE
Allow default file creation with 755 permission

### DIFF
--- a/src/etc/profile
+++ b/src/etc/profile
@@ -1,7 +1,7 @@
 # vi: ts=4 noexpandtab syntax=sh
 
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-
+umask 022
 ENV=$HOME/.shrc; export ENV
 
 # If running interactively, then:


### PR DESCRIPTION
It's necessary that files by default are created with 755 permission -
similar to Ubuntu. Currently they are created with 700 permission.
