### PR TITLE
Allow file creation with default 755 perm over ssh

### DIFF
--- a/patches-buildroot/dropbear-fix-default-fileperms.patch
+++ b/patches-buildroot/dropbear-fix-default-fileperms.patch
@@ -1,0 +1,13 @@
+diff --git a/package/dropbear/S50dropbear b/package/dropbear/S50dropbear
+index a343b9e..dae4d56 100644
+--- a/package/dropbear/S50dropbear
++++ b/package/dropbear/S50dropbear
+@@ -14,7 +14,7 @@ start() {
+ 	if [ ! -d /etc/dropbear ] ; then
+ 		mkdir -p /etc/dropbear
+ 	fi
+-	umask 077
++	umask 022
+ 	start-stop-daemon -S -q -p /var/run/dropbear.pid \
+ 		--exec /usr/sbin/dropbear -- $DROPBEAR_ARGS
+ 	[ $? == 0 ] && echo "OK" || echo "FAIL"

--- a/patches-buildroot/series
+++ b/patches-buildroot/series
@@ -1,2 +1,3 @@
 nfs-utils-enable-nfsv4.patch
 dropbear-fix-path.patch
+dropbear-fix-default-fileperms.patch

--- a/src/sbin/dhclient
+++ b/src/sbin/dhclient
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+udhcpc -i "$1"


### PR DESCRIPTION
The parent directory of the shares created by Manila through ssh needs
to allow read and write permissions to 'others'. The VM launched using
the image by default creates directories without the desired
permissions. So the umask for files created over ssh is changed.
